### PR TITLE
Fix deploy/nightly workflows: install Python dependencies

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,10 @@ jobs:
       - name: Build execution environment
         uses: ./.github/actions/setup-ee
 
+      - name: Install Python dependencies
+        shell: bash
+        run: pip install -r requirements.txt
+
       - name: Generate audience documentation
         shell: bash
         run: make docs

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,8 +24,14 @@ jobs:
       - name: Build execution environment
         uses: ./.github/actions/setup-ee
 
+      - name: Install Python dependencies
+        shell: bash
+        run: pip install -r requirements.txt
+
       - name: Run nightly assessment
         shell: bash
+        env:
+          CONTAINER_RUNTIME: docker
         run: ./scripts/run_nightly_assessment.sh
 
       - name: Generate audience documentation


### PR DESCRIPTION
## Summary
- Add `pip install -r requirements.txt` step to deploy and nightly workflows
- Add `CONTAINER_RUNTIME=docker` to nightly workflow assessment step

The doc generation scripts (make docs, make dashboard, etc.) require jinja2 and
other packages from requirements.txt. The previous PR's deploy workflow failed
because these dependencies weren't installed.

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, deploy workflow succeeds and publishes to gh-pages
- [ ] Dashboard accessible at https://kcaylor.github.io/rcd-cui/

🤖 Generated with [Claude Code](https://claude.com/claude-code)